### PR TITLE
Enable access control via the OpenID Connect provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Etherpad's `requireAuthentication` setting must be `true`.
   name to display in the pad's user list.
 * `response_types` (optional; defaults to `["code"]`): List of OpenID Connect
   response types.
+* `scope` (optional; defaults to `["openid"]`): List of OAuth2 scope strings.
 * `permit_displayname_change` (optional; defaults to `false`): Whether users may
   change their displayed name.
 * `prohibited_usernames` (optional; defaults to `['admin', 'guest']`): List of

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const settings = {
   response_types: ['code'],
   permit_displayname_change: false,
   prohibited_usernames: ['admin', 'guest'],
+  scope: ['openid'],
 };
 let oidcClient = null;
 
@@ -116,7 +117,11 @@ exports.expressCreateServer = (hookName, {app}) => {
     if (req.session.ep_openid_connect == null) req.session.ep_openid_connect = {};
     const oidcSession = req.session.ep_openid_connect;
     oidcSession.next = req.query.redirect_uri || settings.base_url;
-    oidcSession.authParams = {nonce: generators.nonce(), state: generators.state()};
+    oidcSession.authParams = {
+      nonce: generators.nonce(),
+      scope: settings.scope.join(' '),
+      state: generators.state(),
+    };
     res.redirect(oidcClient.authorizationUrl(oidcSession.authParams));
   });
   app.get(ep('logout'), (req, res) => req.session.destroy(() => res.redirect(settings.base_url)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_openid_connect",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_openid_connect",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Etherpad plugin to authenticate users against an OpenID Connect provider.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
@B00tLoad Would you test this to see if it meets your needs? You can install it by running the following in your Etherpad root directory:
```
npm i --no-save --legacy-peer-deps ether/ep_openid_connect#rhansen-userprops
```

Fixes #1