### PR TITLE
Avoid infinite redirect loop with invalid `sub` claims

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,9 +139,9 @@ exports.expressCreateServer = (hookName, {app}) => {
 exports.authenticate = (hookName, {req, res, users}) => {
   if (oidcClient == null) return;
   logger.debug('authenticate hook for', req.url);
-  const {ep_openid_connect: {userinfo = {}} = {}} = req.session;
-  if (userinfo.sub == null || // Nullish means the user isn't authenticated.
-      typeof userinfo.sub !== 'string' || // `sub` is used as the username, so it must be a string.
+  const {ep_openid_connect: {userinfo} = {}} = req.session;
+  if (userinfo == null || // Nullish means the user isn't authenticated.
+      typeof userinfo.sub !== 'string' || // 'sub' claim must exist as a string per OIDC spec.
       userinfo.sub === '' || // Empty string doesn't make sense.
       userinfo.sub === '__proto__' || // Prevent prototype pollution.
       settings.prohibited_usernames.includes(userinfo.sub)) {

--- a/index.js
+++ b/index.js
@@ -140,12 +140,11 @@ exports.authenticate = (hookName, {req, res, users}) => {
   if (oidcClient == null) return;
   logger.debug('authenticate hook for', req.url);
   const {ep_openid_connect: {userinfo = {}} = {}} = req.session;
-  const {sub} = userinfo;
-  if (sub == null || // Nullish means the user isn't authenticated.
-      typeof sub !== 'string' || // `sub` is used as the username, so it must be a string.
-      sub === '' || // Empty string doesn't make sense.
-      sub === '__proto__' || // Prevent prototype pollution.
-      settings.prohibited_usernames.includes(sub)) {
+  if (userinfo.sub == null || // Nullish means the user isn't authenticated.
+      typeof userinfo.sub !== 'string' || // `sub` is used as the username, so it must be a string.
+      userinfo.sub === '' || // Empty string doesn't make sense.
+      userinfo.sub === '__proto__' || // Prevent prototype pollution.
+      settings.prohibited_usernames.includes(userinfo.sub)) {
     // Out of an abundance of caution, clear out the old state, nonce, and userinfo (if present) to
     // force regeneration.
     delete req.session.ep_openid_connect;
@@ -154,8 +153,8 @@ exports.authenticate = (hookName, {req, res, users}) => {
   }
   // Successfully authenticated.
   logger.info('Successfully authenticated user with userinfo:', userinfo);
-  req.session.user = users[sub];
-  if (req.session.user == null) req.session.user = users[sub] = {};
+  req.session.user = users[userinfo.sub];
+  if (req.session.user == null) req.session.user = users[userinfo.sub] = {};
   for (const [propName, descriptor] of Object.entries(settings.user_properties)) {
     if (descriptor.claim != null && descriptor.claim in userinfo) {
       req.session.user[propName] = userinfo[descriptor.claim];

--- a/index.js
+++ b/index.js
@@ -103,9 +103,9 @@ exports.expressCreateServer = (hookName, {app}) => {
       logger.debug(`Processing ${req.url}`);
       const params = oidcClient.callbackParams(req);
       const oidcSession = req.session.ep_openid_connect || {};
-      const {authParams} = oidcSession;
-      if (authParams == null) throw new Error('no authentication paramters found in session state');
-      const tokenset = await oidcClient.callback(endpointUrl('callback'), params, authParams);
+      if (oidcSession.authParams == null) throw new Error('missing authentication paramters');
+      const tokenset =
+          await oidcClient.callback(endpointUrl('callback'), params, oidcSession.authParams);
       oidcSession.userinfo = await oidcClient.userinfo(tokenset);
       // The user has successfully authenticated, but don't set req.session.user here -- do it in
       // the authenticate hook so that Etherpad can log the authentication success. However, DO "log

--- a/index.js
+++ b/index.js
@@ -98,9 +98,9 @@ exports.clientVars = (hookName, context) => {
 exports.expressCreateServer = (hookName, {app}) => {
   if (oidcClient == null) return;
   logger.debug('Configuring auth routes');
-  app.get(ep('callback'), (req, res, next) => {
-    logger.debug(`Processing ${req.url}`);
-    (async () => {
+  app.get(ep('callback'), async (req, res, next) => {
+    try {
+      logger.debug(`Processing ${req.url}`);
       const params = oidcClient.callbackParams(req);
       const oidcSession = req.session.ep_openid_connect || {};
       const {authParams} = oidcSession;
@@ -117,7 +117,9 @@ exports.expressCreateServer = (hookName, {app}) => {
       // transient backchannel failure.
       delete oidcSession.authParams;
       delete oidcSession.next;
-    })().catch(next);
+    } catch (err) {
+      return next(err);
+    }
   });
   app.get(ep('login'), (req, res, next) => {
     logger.debug(`Processing ${req.url}`);


### PR DESCRIPTION
This fixes a bug introduced in commit 97d72cb8798c880e664d77299b734b7a372bae27.