### PR TITLE
Don't act as an open redirector

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ exports.expressCreateServer = (hookName, {app}) => {
     }
     if (req.session.ep_openid_connect == null) req.session.ep_openid_connect = {};
     const oidcSession = req.session.ep_openid_connect;
-    oidcSession.next = req.query.redirect_uri || settings.base_url;
     const commonParams = {
       nonce: generators.nonce(),
       scope: settings.scope.join(' '),
@@ -207,8 +206,9 @@ exports.authenticate = (hookName, {req, res, users}) => {
 
 exports.authnFailure = (hookName, {req, res}) => {
   if (oidcClient == null) return;
-  const url = new URL(req.url.substr(1), settings.base_url).toString();
-  res.redirect(`${endpointUrl('login')}?redirect_uri=${encodeURIComponent(url)}`);
+  if (req.session.ep_openid_connect == null) req.session.ep_openid_connect = {};
+  req.session.ep_openid_connect.next = new URL(req.url.slice(1), settings.base_url).toString();
+  res.redirect(endpointUrl('login'));
   return true;
 };
 

--- a/static/tests/backend/specs/tests.js
+++ b/static/tests/backend/specs/tests.js
@@ -63,18 +63,13 @@ describe(__filename, function () {
   });
 
   it('not logged in redirects to login endpoint', async function () {
-    const params = new URLSearchParams();
-    params.append('redirect_uri', new URL('/', common.baseUrl));
-    const wantRedirect = new URL(`/ep_openid_connect/login?${params}`, common.baseUrl).toString();
     await agent.get(common.baseUrl)
         .expect(302)
-        .expect('location', wantRedirect);
+        .expect('location', new URL('/ep_openid_connect/login', common.baseUrl).toString());
   });
 
   it('login endpoint redirects to authorization URL', async function () {
-    const params = new URLSearchParams();
-    params.append('redirect_uri', new URL('/', common.baseUrl));
-    await agent.get(new URL(`/ep_openid_connect/login?${params}`, common.baseUrl))
+    await agent.get(new URL('/ep_openid_connect/login', common.baseUrl))
         .expect(302)
         .expect('location', /.*/)
         .expect((res) => {
@@ -217,6 +212,6 @@ describe(__filename, function () {
         .expect(302)
         .expect('location', /./)
         .expect((res) => assert(res.headers.location.startsWith(
-            new URL('/ep_openid_connect/login?', common.baseUrl).toString())));
+            new URL('/ep_openid_connect/login', common.baseUrl).toString())));
   });
 });


### PR DESCRIPTION
For rationale, see: https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-19.html#section-4.10.1