### PR TITLE
Fix: pin lru-cache to prevent LRU constructor crash (#113)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@etherpad/node-openid-client": "npm:@jsr/etherpad__node-openid-client@^0.1.0",
     "ajv": "^8.18.0",
+    "lru-cache": "^6.0.0",
     "openid-client": "^5.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes #113 — `TypeError: LRU is not a constructor`

`openid-client` depends on `lru-cache ^6.0.0`, but pnpm deduplication can resolve v7+ where the API changed. Pinning `lru-cache ^6.0.0` as a direct dependency ensures the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)