### PR TITLE
fix: allow non-string defaults in user_properties (#100)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ const validSettings = new Ajv().compile({
     user_properties: {values: {
       optionalProperties: {
         claim: {type: 'string'},
-        default: {type: 'string'},
+        // `default` is assigned verbatim to `req.session.user[propName]`,
+        // so any JSON value (boolean for is_admin/readOnly/canCreate,
+        // number, string, …) is fine. Use the JTD empty form so we don't
+        // reject non-string defaults (#100).
+        default: {},
       },
       nullable: true,
     }},
@@ -271,4 +275,5 @@ exports.preAuthorize = (hookName, {req}) => {
 
 exports.exportedForTestingOnly = {
   defaultSettings,
+  validSettings,
 };

--- a/static/tests/backend/specs/default_type.js
+++ b/static/tests/backend/specs/default_type.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('assert').strict;
+const {validSettings} = require('../../../..').exportedForTestingOnly;
+
+const baseSettings = () => ({
+  client_id: 'cid',
+  client_secret: 'secret',
+  base_url: 'https://example.test/',
+});
+
+describe(__filename, function () {
+  it('still accepts a string default on user_properties', function () {
+    const s = {
+      ...baseSettings(),
+      user_properties: {displayname: {claim: 'name', default: 'Anon'}},
+    };
+    assert(validSettings(s),
+        `expected valid settings, got errors: ${JSON.stringify(validSettings.errors)}`);
+  });
+
+  it('accepts a boolean default on user_properties (regression for #100)', function () {
+    const s = {
+      ...baseSettings(),
+      user_properties: {
+        is_admin: {claim: 'etherpad_is_admin', default: false},
+        readOnly: {default: false},
+        canCreate: {default: true},
+      },
+    };
+    assert(validSettings(s),
+        `expected boolean defaults to validate, got errors: ` +
+        `${JSON.stringify(validSettings.errors)}`);
+  });
+
+  it('accepts a numeric default on user_properties', function () {
+    const s = {
+      ...baseSettings(),
+      user_properties: {quota: {default: 100}},
+    };
+    assert(validSettings(s),
+        `expected numeric defaults to validate, got errors: ` +
+        `${JSON.stringify(validSettings.errors)}`);
+  });
+});


### PR DESCRIPTION
Fixes #100. The JTD schema rejected anything but a string in `user_properties.*.default`, so operators could not set `is_admin`/`readOnly`/`canCreate` to `false`/`true` defaults. Relax that slot to the JTD empty form (`{}`) so any JSON value is accepted — the default is assigned verbatim to `req.session.user[propName]` at authenticate time. Expose the compiled validator on `exportedForTestingOnly` and add specs that confirm string, boolean, and numeric defaults all validate.