### PR TITLE
fix: drop @jsr-aliased dep so npm install works out of the box (#115)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@jsr:registry=https://npm.jsr.io

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const Ajv = require('ajv/dist/jtd');
 const {URL} = require('url');
-const {Issuer, generators} = require('@etherpad/node-openid-client');
+const {Issuer, generators} = require('openid-client');
 
 let logger = {};
 for (const level of ['debug', 'info', 'warn', 'error']) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/ether/ep_openid_connect#readme",
   "dependencies": {
-    "@etherpad/node-openid-client": "npm:@jsr/etherpad__node-openid-client@^0.1.0",
     "ajv": "^8.18.0",
     "openid-client": "^5.7.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@etherpad/node-openid-client':
-        specifier: npm:@jsr/etherpad__node-openid-client@^0.1.0
-        version: '@jsr/etherpad__node-openid-client@0.1.0'
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -75,9 +72,6 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
-
-  '@jsr/etherpad__node-openid-client@0.1.0':
-    resolution: {integrity: sha512-HPURcH7nlZ6j811lccaD/bFVCYu18UKMwEEfPJbgEu+bEUtdKqH3sX1UxQ3Mx708qYCszJHWiD9q83QtcjnVZA==, tarball: https://npm.jsr.io/~/11/@jsr/etherpad__node-openid-client/0.1.0.tgz}
 
   '@koa/cors@5.0.0':
     resolution: {integrity: sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==}
@@ -1730,10 +1724,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
-
-  '@jsr/etherpad__node-openid-client@0.1.0':
-    dependencies:
-      jose: 4.15.9
 
   '@koa/cors@5.0.0':
     dependencies:

--- a/static/tests/backend/oidc-provider.js
+++ b/static/tests/backend/oidc-provider.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const MemoryAdapter = require('oidc-provider/lib/adapters/memory_adapter');
-const Provider = require('oidc-provider');
+// oidc-provider v8+ is ESM-only (`"type": "module"` in package.json). When
+// Node `require()`s it from a CommonJS module, the returned value is the
+// ESM namespace object, not the class itself — so `.default` is needed.
+const MemoryAdapter = require('oidc-provider/lib/adapters/memory_adapter').default;
+const Provider = require('oidc-provider').default;
 const common = require('ep_etherpad-lite/tests/backend/common');
 const http = require('http');
 const util = require('util');

--- a/static/tests/backend/specs/tests.js
+++ b/static/tests/backend/specs/tests.js
@@ -36,7 +36,16 @@ describe(__filename, function () {
     await common.init();
     if (!plugins.hooks.clientVars) plugins.hooks.clientVars = [];
     backup.hooks = {clientVars: plugins.hooks.clientVars};
-    backup.settings = {...settings};
+    // Only capture the fields the tests actually mutate. Etherpad's
+    // settings module now exposes several read-only getters (e.g.
+    // abiwordAvailable), which made the old `{...settings}` + Object.assign
+    // cleanup throw "Cannot set property … of #<Object> which has only a
+    // getter".
+    backup.settings = {
+      requireAuthentication: settings.requireAuthentication,
+      requireAuthorization: settings.requireAuthorization,
+      users: settings.users,
+    };
     provider = new OidcProvider();
     const clients =
         [{...client, redirect_uris: [new URL('/ep_openid_connect/callback', common.baseUrl)]}];
@@ -59,7 +68,11 @@ describe(__filename, function () {
     if (socket != null) socket.close();
     socket = null;
     Object.assign(plugins.hooks, backup.hooks);
-    Object.assign(settings, backup.settings);
+    // Restore only the fields we changed in beforeEach — see note in
+    // `before()` about read-only getters on the settings module.
+    settings.requireAuthentication = backup.settings.requireAuthentication;
+    settings.requireAuthorization = backup.settings.requireAuthorization;
+    settings.users = backup.settings.users;
   });
 
   after(async function () {


### PR DESCRIPTION
Fixes #115. The package aliased `@etherpad/node-openid-client` to the JSR package `npm:@jsr/etherpad__node-openid-client@^0.1.0`, but the `@jsr` scope lives on `https://npm.jsr.io` (not `registry.npmjs.org`). `npm install ep_openid_connect` and Etherpad's own `live-plugin-manager` therefore 404ed on the alias target. Both were unusable without a manually-edited `.npmrc`.

`openid-client@^5.7.1` was already listed as a real dependency, and `Issuer`/`generators` import the same from it — the JSR alias was just an unused indirection. Require `openid-client` directly, drop the alias from `package.json`, and delete the now-unused `@jsr:registry` line in `.npmrc`.

Also unblocks CI in this repo (the old ep_openid_connect#129 backend run failed on the JSR 404, not the actual test).