### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_openid_connect/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_openid_connect/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_openid_connect/actions/workflows/test-and-release.yml)
 
-# ep\_openid\_connect
+# OpenID Connect Authentication for Etherpad
 
 Etherpad plugin to authenticate users against an OpenID Connect provider.
 


### PR DESCRIPTION
Replace the placeholder `ep_openid_connect` heading in README.md with "OpenID Connect Authentication for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.