### PR TITLE
test: follow all redirect-class statuses, not just 303

### DIFF
--- a/static/tests/backend/login.js
+++ b/static/tests/backend/login.js
@@ -5,8 +5,13 @@ const common = require('ep_etherpad-lite/tests/backend/common');
 
 const logger = common.logger;
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const followRedirects = async (agent, res) => {
-  if (res.status !== 303) return res;
+  // Older oidc-provider used 303 for auth→interaction redirects; recent
+  // releases use 302 (and 307/308 for POST-safe redirects). Follow any
+  // redirect-class status so the test harness doesn't stop at `/auth?...`
+  // when it should have continued on to `/interaction/...`.
+  if (!REDIRECT_STATUSES.has(res.status)) return res;
   const url = new URL(res.headers.location, res.request.url);
   logger.debug(`redirected to ${url}`);
   return await followRedirects(agent, await agent.get(url));


### PR DESCRIPTION
The backend tests' `followRedirects` helper only chased HTTP 303 responses. Newer `oidc-provider` releases send 302 from `/auth` → `/interaction/` (and 307/308 for POST-safe redirects), so the harness stalled at `/auth?client_id=...` and every login-flow assertion (90 of them) failed with "expected .../auth?... to start with .../interaction/". Follow any redirect-class status (301/302/303/307/308) so the harness reaches the interaction page regardless of which verb the server picked.