### PR TITLE
fix: allow configuring token endpoint auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Etherpad's `requireAuthentication` setting must be `true`.
 * `client_id` (required): The OAuth2 client ID issued by the identity provider.
 * `client_secret` (required): The OAuth2 client secret issued by the identity
   provider.
+* `token_endpoint_auth_method` (optional; defaults to `client_secret_basic`):
+  Client authentication method to use for token endpoint requests. Supported
+  values are `client_secret_basic` and `client_secret_post`. Use
+  `client_secret_post` if your identity provider expects the client secret in
+  the token request body instead of the HTTP `Authorization` header.
 * `base_url` (required): The public base Etherpad URL. When registering Etherpad
   with your identity provider, the redirect URL (a.k.a. callback URL) is this
   base URL plus `/ep_openid_connect/callback`.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ for (const level of ['debug', 'info', 'warn', 'error']) {
 const defaultSettings = {
   prohibited_usernames: ['admin', 'guest'],
   scope: ['openid'],
+  token_endpoint_auth_method: 'client_secret_basic',
   user_properties: {},
 };
 let settings;
@@ -33,6 +34,7 @@ const validSettings = new Ajv().compile({
     issuer_metadata: {},
     prohibited_usernames: {elements: {type: 'string'}},
     scope: {elements: {type: 'string'}},
+    token_endpoint_auth_method: {enum: ['client_secret_basic', 'client_secret_post']},
     user_properties: {values: {
       optionalProperties: {
         claim: {type: 'string'},
@@ -100,11 +102,25 @@ const discoverConfig = async (issuerUrl, clientId, clientAuth) => {
   }
 };
 
+const getClientAuth = (settings) => {
+  switch (settings.token_endpoint_auth_method) {
+    case 'client_secret_basic':
+      // eslint-disable-next-line new-cap
+      return oidc.ClientSecretBasic(settings.client_secret);
+    case 'client_secret_post':
+      // eslint-disable-next-line new-cap
+      return oidc.ClientSecretPost(settings.client_secret);
+    default:
+      throw new Error(
+          `Unsupported token endpoint auth method: ${settings.token_endpoint_auth_method}`);
+  }
+};
+
 const buildConfig = async (settings) => {
   // openid-client@5 defaulted the token endpoint auth method to
   // `client_secret_basic`; v6 defaults to `client_secret_post`. Pin the
-  // method explicitly so existing IdP registrations keep working.
-  const clientAuth = oidc.ClientSecretBasic(settings.client_secret);
+  // default method explicitly so existing IdP registrations keep working.
+  const clientAuth = getClientAuth(settings);
   if (settings.issuer) {
     const config =
         await discoverConfig(settings.issuer, settings.client_id, clientAuth);

--- a/static/tests/backend/specs/tests.js
+++ b/static/tests/backend/specs/tests.js
@@ -125,6 +125,31 @@ describe(__filename, function () {
     assert.equal(msg.data.readonly, false);
   });
 
+  describe('token_endpoint_auth_method', function () {
+    for (const tokenEndpointAuthMethod of ['client_secret_basic', 'client_secret_post']) {
+      it(`supports ${tokenEndpointAuthMethod}`, async function () {
+        await epOpenidConnect.loadSettings('loadSettings', {settings: {ep_openid_connect: {
+          ...pluginSettings,
+          token_endpoint_auth_method: tokenEndpointAuthMethod,
+        }}});
+        const padId = common.randomString();
+        const url = new URL(`/p/${padId}`, common.baseUrl).toString();
+        const res = await login(agent, issuer, url, 'normalUser');
+        assert.equal(res.request.url, url);
+        assert.equal(res.status, 200);
+      });
+    }
+
+    it('rejects unsupported methods', async function () {
+      await epOpenidConnect.loadSettings('loadSettings', {settings: {ep_openid_connect: {
+        ...pluginSettings,
+        token_endpoint_auth_method: 'unsupported',
+      }}});
+      await agent.get(new URL('/ep_openid_connect/login', common.baseUrl))
+          .expect(401);
+    });
+  });
+
   it('noCreate user is unable to create a pad', async function () {
     const padId = common.randomString();
     const url = new URL(`/p/${padId}`, common.baseUrl).toString();


### PR DESCRIPTION
Fixes #146

This MR adds a new optional `token_endpoint_auth_method` configuration value that can be provided via the Etherpad configuration file. This allows overriding the client auth method used, while defaulting to `client_secret_basic`, which is hardcoded at the time of writing.