### PR TITLE
fix: auto-pick token endpoint auth method from discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+#### Behaviour changes
+
+  * `token_endpoint_auth_method` now defaults to auto-detection from the
+    identity provider's discovery document. The plugin prefers
+    `client_secret_post` when advertised and falls back to
+    `client_secret_basic`. This fixes silent token-endpoint
+    `WWWAuthenticateChallengeError` failures on GitLab.com (which advertises
+    both methods but rejects `client_secret_basic`). Users who previously
+    relied on the `client_secret_basic` default without setting it explicitly
+    may now exchange tokens via `client_secret_post`; set the option
+    explicitly to pin a specific method.
+
 ## v3.0.0
 
 Released 2022-03-04.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ Etherpad's `requireAuthentication` setting must be `true`.
 * `client_id` (required): The OAuth2 client ID issued by the identity provider.
 * `client_secret` (required): The OAuth2 client secret issued by the identity
   provider.
-* `token_endpoint_auth_method` (optional; defaults to `client_secret_basic`):
-  Client authentication method to use for token endpoint requests. Supported
-  values are `client_secret_basic` and `client_secret_post`. Use
-  `client_secret_post` if your identity provider expects the client secret in
-  the token request body instead of the HTTP `Authorization` header.
+* `token_endpoint_auth_method` (optional; auto-detected by default): Client
+  authentication method to use for token endpoint requests. Supported values
+  are `client_secret_basic` and `client_secret_post`. When not set, the plugin
+  inspects the identity provider's discovery document
+  (`token_endpoint_auth_methods_supported`) and picks `client_secret_post` if
+  the provider advertises it, otherwise `client_secret_basic`. Set this
+  explicitly to force a specific method — for example, if your identity
+  provider advertises both but your client is registered for only one.
 * `base_url` (required): The public base Etherpad URL. When registering Etherpad
   with your identity provider, the redirect URL (a.k.a. callback URL) is this
   base URL plus `/ep_openid_connect/callback`.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ for (const level of ['debug', 'info', 'warn', 'error']) {
 const defaultSettings = {
   prohibited_usernames: ['admin', 'guest'],
   scope: ['openid'],
-  token_endpoint_auth_method: 'client_secret_basic',
   user_properties: {},
 };
 let settings;
@@ -78,7 +77,41 @@ const isHttp = (urlString) => {
   }
 };
 
-const discoverConfig = async (issuerUrl, clientId, clientAuth) => {
+// Pick the token endpoint auth method to use, given the IdP's advertised
+// `token_endpoint_auth_methods_supported` and any explicit override from
+// settings. Pure; exported for unit testing.
+//
+// Preference order when no override is set:
+//   1. `client_secret_post` if the IdP advertises it (matches openid-client@6's
+//      own default and works with every public IdP we've tested — notably
+//      GitLab.com, which rejects `client_secret_basic` at the token endpoint
+//      even though it lists it in discovery).
+//   2. `client_secret_basic` if the IdP advertises only that.
+//   3. `client_secret_basic` if the IdP advertises nothing we recognise (RFC
+//      8414 §2 says the absence of the field defaults to `client_secret_basic`).
+const pickAuthMethod = (supported, override) => {
+  if (override) return override;
+  if (Array.isArray(supported)) {
+    if (supported.includes('client_secret_post')) return 'client_secret_post';
+    if (supported.includes('client_secret_basic')) return 'client_secret_basic';
+  }
+  return 'client_secret_basic';
+};
+
+const clientAuthFor = (method, secret) => {
+  switch (method) {
+    case 'client_secret_basic':
+      // eslint-disable-next-line new-cap
+      return oidc.ClientSecretBasic(secret);
+    case 'client_secret_post':
+      // eslint-disable-next-line new-cap
+      return oidc.ClientSecretPost(secret);
+    default:
+      throw new Error(`Unsupported token endpoint auth method: ${method}`);
+  }
+};
+
+const fetchServerMetadata = async (issuerUrl, clientId) => {
   const url = new URL(issuerUrl);
   // https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery says that the URI
   // must not have query or fragment components.
@@ -94,7 +127,13 @@ const discoverConfig = async (issuerUrl, clientId, clientAuth) => {
     ? {execute: [oidc.allowInsecureRequests]}
     : undefined;
   try {
-    return await oidc.discovery(url, clientId, undefined, clientAuth, options);
+    // Discovery fetches the .well-known/openid-configuration document. The
+    // clientAuthentication argument is irrelevant for that HTTP request — it
+    // only matters when the Configuration is later used to exchange a code
+    // for a token — so we can pass `undefined` here and bind the real method
+    // below once we know what the IdP supports.
+    const tempConfig = await oidc.discovery(url, clientId, undefined, undefined, options);
+    return tempConfig.serverMetadata();
   } catch (err) {
     // The URL used to get the issuer metadata doesn't exactly follow RFC 8615; see:
     // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
@@ -111,36 +150,30 @@ const discoverConfig = async (issuerUrl, clientId, clientAuth) => {
   }
 };
 
-const getClientAuth = (settings) => {
-  switch (settings.token_endpoint_auth_method) {
-    case 'client_secret_basic':
-      // eslint-disable-next-line new-cap
-      return oidc.ClientSecretBasic(settings.client_secret);
-    case 'client_secret_post':
-      // eslint-disable-next-line new-cap
-      return oidc.ClientSecretPost(settings.client_secret);
-    default:
-      throw new Error(
-          `Unsupported token endpoint auth method: ${settings.token_endpoint_auth_method}`);
-  }
-};
-
 const buildConfig = async (settings) => {
-  // openid-client@5 defaulted the token endpoint auth method to
-  // `client_secret_basic`; v6 defaults to `client_secret_post`. Pin the
-  // default method explicitly so existing IdP registrations keep working.
-  const clientAuth = getClientAuth(settings);
+  // Resolve the server metadata (either via discovery or from the inline
+  // `issuer_metadata` blob) BEFORE choosing an auth method, so we can pick
+  // one the IdP actually advertises.
+  let serverMetadata;
+  let phaseLog;
   if (settings.issuer) {
-    const config =
-        await discoverConfig(settings.issuer, settings.client_id, clientAuth);
-    logger.info('OpenID Connect Discovery complete.');
-    return config;
+    serverMetadata = await fetchServerMetadata(settings.issuer, settings.client_id);
+    phaseLog = 'OpenID Connect Discovery complete.';
+  } else {
+    serverMetadata = settings.issuer_metadata;
+    phaseLog = 'Configured from issuer_metadata.';
   }
-  const config =
-      new oidc.Configuration(settings.issuer_metadata, settings.client_id, undefined, clientAuth);
-  if (isHttp(settings.issuer_metadata && settings.issuer_metadata.issuer)) {
+  const method = pickAuthMethod(
+      serverMetadata && serverMetadata.token_endpoint_auth_methods_supported,
+      settings.token_endpoint_auth_method);
+  const clientAuth = clientAuthFor(method, settings.client_secret);
+  const config = new oidc.Configuration(
+      serverMetadata, settings.client_id, undefined, clientAuth);
+  if (isHttp(serverMetadata && serverMetadata.issuer)) {
     oidc.allowInsecureRequests(config);
   }
+  const source = settings.token_endpoint_auth_method ? 'configured' : 'auto-picked';
+  logger.info(`${phaseLog} Token endpoint auth method: ${method} (${source}).`);
   return config;
 };
 
@@ -179,7 +212,6 @@ exports.loadSettings = async (hookName, {settings: {ep_openid_connect: s = {}}})
   if (!settings.base_url.endsWith('/')) settings.base_url += '/';
   logger.debug('Settings:', {...settings, client_secret: '********'});
   oidcConfig = await buildConfig(settings);
-  logger.info('Configured.');
 };
 
 exports.expressCreateServer = (hookName, {app}) => {
@@ -336,5 +368,6 @@ exports.preAuthorize = (hookName, {req}) => {
 exports.exportedForTestingOnly = {
   callbackUrlFromRequest,
   defaultSettings,
+  pickAuthMethod,
   validSettings,
 };

--- a/static/tests/backend/specs/auto_pick_auth_method.js
+++ b/static/tests/backend/specs/auto_pick_auth_method.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// End-to-end coverage for the token_endpoint_auth_method auto-pick: spin up a
+// dedicated OIDC provider whose discovery doc advertises only one auth method,
+// load the plugin without an explicit override, and confirm a real login flow
+// succeeds — i.e. the plugin chose the advertised method.
+
+const OidcProvider = require('../oidc-provider');
+const assert = require('assert').strict;
+const common = require('ep_etherpad-lite/tests/backend/common');
+const epOpenidConnect = require('../../../../index');
+const login = require('../login');
+const plugins = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+const supertest = require('supertest');
+
+describe(__filename, function () {
+  let agent;
+  let provider;
+  const backup = {};
+  const client = {
+    client_id: 'the_client_id',
+    client_secret: 'the_client_secret',
+  };
+  const basePluginSettings = {
+    ...client,
+    scope: ['openid', 'etherpad'],
+    user_properties: {
+      is_admin: {claim: 'etherpad_is_admin'},
+      readOnly: {claim: 'etherpad_readOnly'},
+      canCreate: {claim: 'etherpad_canCreate'},
+    },
+  };
+
+  before(async function () {
+    await common.init();
+    if (!plugins.hooks.clientVars) plugins.hooks.clientVars = [];
+    backup.hooks = {clientVars: plugins.hooks.clientVars};
+    backup.settings = {
+      requireAuthentication: settings.requireAuthentication,
+      requireAuthorization: settings.requireAuthorization,
+      users: settings.users,
+    };
+  });
+
+  beforeEach(function () {
+    agent = supertest.agent('');
+    settings.requireAuthentication = true;
+    settings.requireAuthorization = false;
+    settings.users = {};
+  });
+
+  afterEach(async function () {
+    if (provider != null) await provider.stop();
+    provider = null;
+    Object.assign(plugins.hooks, backup.hooks);
+    settings.requireAuthentication = backup.settings.requireAuthentication;
+    settings.requireAuthorization = backup.settings.requireAuthorization;
+    settings.users = backup.settings.users;
+  });
+
+  // Restart `provider` with the given allowed auth methods, then load the
+  // plugin pointed at it with NO explicit token_endpoint_auth_method (so the
+  // picker runs).
+  const startProvider = async (allowedAuthMethods) => {
+    const redirectUri = new URL('/ep_openid_connect/callback', common.baseUrl).href;
+    provider = new OidcProvider();
+    await provider.start({
+      // oidc-provider v9: the global allow-list drives the advertised
+      // token_endpoint_auth_methods_supported and is enforced at the token
+      // endpoint. Each client must also declare which method it uses.
+      clientAuthMethods: allowedAuthMethods,
+      clients: [{
+        ...client,
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: allowedAuthMethods[0],
+      }],
+    });
+    await epOpenidConnect.loadSettings('loadSettings', {settings: {ep_openid_connect: {
+      ...basePluginSettings,
+      base_url: common.baseUrl,
+      issuer: provider.issuer,
+      // Deliberately omit token_endpoint_auth_method — that's what we're testing.
+    }}});
+  };
+
+  it('picks client_secret_post when only that is advertised', async function () {
+    await startProvider(['client_secret_post']);
+    const url = new URL(`/p/${common.randomString()}`, common.baseUrl).toString();
+    const res = await login(agent, provider.issuer, url, 'normalUser');
+    assert.equal(res.request.url, url,
+        `expected redirect back to ${url}, got ${res.request.url}`);
+    assert.equal(res.status, 200);
+  });
+
+  it('picks client_secret_basic when only that is advertised', async function () {
+    await startProvider(['client_secret_basic']);
+    const url = new URL(`/p/${common.randomString()}`, common.baseUrl).toString();
+    const res = await login(agent, provider.issuer, url, 'normalUser');
+    assert.equal(res.request.url, url,
+        `expected redirect back to ${url}, got ${res.request.url}`);
+    assert.equal(res.status, 200);
+  });
+
+  it('prefers client_secret_post when both are advertised', async function () {
+    // When both methods are on offer the plugin must pick _post (matches the
+    // openid-client@6 default and is the one GitLab.com actually accepts at
+    // the token endpoint). The test client is registered as _post-only, so a
+    // _basic attempt would 401 at the token endpoint.
+    await startProvider(['client_secret_post', 'client_secret_basic']);
+    const url = new URL(`/p/${common.randomString()}`, common.baseUrl).toString();
+    const res = await login(agent, provider.issuer, url, 'normalUser');
+    assert.equal(res.request.url, url,
+        `expected redirect back to ${url}, got ${res.request.url}`);
+    assert.equal(res.status, 200);
+  });
+});

--- a/static/tests/backend/specs/pick_auth_method.js
+++ b/static/tests/backend/specs/pick_auth_method.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('assert').strict;
+const {pickAuthMethod} = require('../../../..').exportedForTestingOnly;
+
+describe(__filename, function () {
+  describe('with no override', function () {
+    it('prefers client_secret_post when advertised', function () {
+      assert.equal(
+          pickAuthMethod(['client_secret_basic', 'client_secret_post']),
+          'client_secret_post');
+    });
+
+    it('uses client_secret_basic when only that is advertised', function () {
+      assert.equal(pickAuthMethod(['client_secret_basic']), 'client_secret_basic');
+    });
+
+    it('uses client_secret_post when only that is advertised', function () {
+      assert.equal(pickAuthMethod(['client_secret_post']), 'client_secret_post');
+    });
+
+    it('ignores unsupported methods', function () {
+      // None of these are methods this plugin can implement, so the picker
+      // must fall back rather than pretend to support them.
+      assert.equal(
+          pickAuthMethod(['private_key_jwt', 'client_secret_jwt', 'none']),
+          'client_secret_basic');
+    });
+
+    it('prefers client_secret_post even when other methods are advertised first', function () {
+      assert.equal(
+          pickAuthMethod(['private_key_jwt', 'client_secret_post', 'client_secret_basic']),
+          'client_secret_post');
+    });
+
+    it('falls back to client_secret_basic when supported is undefined', function () {
+      // RFC 8414 §2: absence of token_endpoint_auth_methods_supported defaults
+      // to client_secret_basic.
+      assert.equal(pickAuthMethod(undefined), 'client_secret_basic');
+    });
+
+    it('falls back to client_secret_basic when supported is empty', function () {
+      assert.equal(pickAuthMethod([]), 'client_secret_basic');
+    });
+
+    it('falls back to client_secret_basic when supported is not an array', function () {
+      assert.equal(pickAuthMethod('client_secret_post'), 'client_secret_basic');
+      assert.equal(pickAuthMethod(null), 'client_secret_basic');
+    });
+  });
+
+  describe('with override', function () {
+    it('honours an explicit client_secret_basic override', function () {
+      assert.equal(
+          pickAuthMethod(['client_secret_post'], 'client_secret_basic'),
+          'client_secret_basic');
+    });
+
+    it('honours an explicit client_secret_post override', function () {
+      assert.equal(
+          pickAuthMethod(['client_secret_basic'], 'client_secret_post'),
+          'client_secret_post');
+    });
+
+    it('honours override even when supported list is missing', function () {
+      assert.equal(
+          pickAuthMethod(undefined, 'client_secret_post'),
+          'client_secret_post');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 3.0.27 still pinned `token_endpoint_auth_method` to `client_secret_basic` by default to preserve the openid-client@5 behaviour. GitLab.com advertises both methods but **rejects** `client_secret_basic` at the token endpoint — every fresh GitLab install crashes the callback with `WWWAuthenticateChallengeError` deep in `oauth4webapi` (same stack as #146, also seen on thmo's Etherpad 2.7.3 instance this week).
- Make the default auto-detect from the IdP's discovery document. Prefer `client_secret_post` when advertised (matches openid-client@6's own default and every public IdP I tested), fall back to `client_secret_basic` otherwise.
- Setting `token_endpoint_auth_method` explicitly still pins the method (escape hatch for IdPs where only one option is registered on the client).

## How I verified

- 11 new unit tests for the pure picker — override / `_post` preferred / `_basic` fallback / unsupported methods ignored / missing / empty / non-array `supported`.
- 3 new integration tests — spin up an `oidc-provider` that advertises *only* the named method(s) (and registers the client for that method), drive a real login, confirm it completes.
- All 3 pre-existing explicit-override tests still pass.
- Full suite: **121 passing, 0 failing**.
- **Live end-to-end against gitlab.com with no override:** the startup log now reads `Token endpoint auth method: client_secret_post (auto-picked).` and the callback completes with `Successfully authenticated user with userinfo: { sub: '38284172', name: 'John McLear', ... }` followed by `[CREATE] pad:…`.

## Behaviour change note (CHANGELOG entry included)

Anyone who was relying on the implicit `client_secret_basic` default *and* whose IdP advertises `client_secret_post` will now use `_post`. This was the GitLab case and is the intended fix. Anyone who needs `_basic` specifically can keep it by setting `token_endpoint_auth_method: client_secret_basic` explicitly — coverage retained.

## Test plan

- [ ] CI green on backend-tests
- [ ] CI green on frontend-tests
- [ ] At least one downstream user with a non-GitLab IdP (Keycloak / Authentik / Auth0) confirms no regression after upgrading

🤖 Generated with [Claude Code](https://claude.com/claude-code)